### PR TITLE
getDatatype and getLanguage in table

### DIFF
--- a/proposed/rdf/rdf.md
+++ b/proposed/rdf/rdf.md
@@ -235,6 +235,8 @@ Bold methods are unique to this interface, the rest *comes* from the Node.
 | Methods                        |
 |:-------------------------------|
 | **getValue**                   |
+| **getDatatype**                |
+| **getLanguage**                |
 | isBlank                        |
 | isLiteral                      |
 | isNamed                        |


### PR DESCRIPTION
two methods missing in the Literal table (I guess)